### PR TITLE
Add Prisma client and Dockerfile improvements

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json tsconfig.json ./
-RUN npm install && npm cache clean --force
+COPY package.json package-lock.json tsconfig.json ./
+RUN npm ci && npm cache clean --force
 COPY prisma prisma
 RUN npx prisma generate
 COPY src src

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "prisma": "^4.0.0"
+    "prisma": "^4.0.0",
+    "@prisma/client": "^4.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",


### PR DESCRIPTION
## Summary
- add `@prisma/client` dependency
- update backend Dockerfile to copy `package-lock.json` and use `npm ci`

## Testing
- `npm install` *(fails: 403 Forbidden because internet access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687ebedec3a4832e868a16910bdd77b5