### PR TITLE
Limit volume mounts in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The `docker-compose.yml` file starts the database, backend and frontend services
 2. Copy `.env.example` to `.env` and adjust the variables if necessary.
 3. Run `docker-compose up --build` to start the stack.
 
+The compose file mounts only the `src` folders from `backend` and `frontend` so
+that `node_modules` installed during the Docker build remain intact.  If you
+change dependencies or other configuration files, rebuild the containers.
+
 The frontend will be available on `http://localhost:5173` and the backend API on `http://localhost:3000` by default.
 
 ## Features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       DATABASE_URL: postgres://postgres:postgres@db:5432/rental
       PORT: 3000
     volumes:
-      - ./backend:/app
+      - ./backend/src:/app/src
+      - ./backend/prisma:/app/prisma
     ports:
       - "3000:3000"
     depends_on:
@@ -26,7 +27,7 @@ services:
   frontend:
     build: ./frontend
     volumes:
-      - ./frontend:/app
+      - ./frontend/src:/app/src
     ports:
       - "5173:5173"
     depends_on:


### PR DESCRIPTION
## Summary
- mount only `src` folders from backend and frontend in compose
- document new compose behavior

## Testing
- `docker-compose config` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687ebee0b3f0832e8c2a515abd7a93ed